### PR TITLE
Add containers/ folder with Dockerfiles, READMEs, and Forgejo workflows

### DIFF
--- a/.forgejo/workflows/build-push-cisco-yang-explorer.yml
+++ b/.forgejo/workflows/build-push-cisco-yang-explorer.yml
@@ -1,0 +1,40 @@
+---
+name: Build and Push docker-alpine-cisco-yang-explorer
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
+
+jobs:
+  build-and-push:
+    runs-on: forgejo-runner
+    container:
+      image: renedocker82/forgejo-runner:42
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USERNAME_RM82 }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+
+      - name: Log in to Docker Hub
+        run: |
+          echo "${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME_RM82 }}" --password-stdin
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          docker buildx build \
+            --push \
+            -t networklessons/docker-alpine-cisco-yang-explorer:latest \
+            -t networklessons/docker-alpine-cisco-yang-explorer:${{ forgejo.run_number }} \
+            containers/docker-alpine-cisco-yang-explorer/

--- a/.forgejo/workflows/build-push-cisco-yang-explorer.yml
+++ b/.forgejo/workflows/build-push-cisco-yang-explorer.yml
@@ -12,8 +12,8 @@ jobs:
     container:
       image: renedocker82/forgejo-runner:42
       credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME_RM82 }}
-        password: ${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,7 +23,7 @@ jobs:
 
       - name: Log in to Docker Hub
         run: |
-          echo "${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME_RM82 }}" --password-stdin
+          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
 
       - name: Extract metadata
         id: meta

--- a/.forgejo/workflows/build-push-freeradius.yml
+++ b/.forgejo/workflows/build-push-freeradius.yml
@@ -12,8 +12,8 @@ jobs:
     container:
       image: renedocker82/forgejo-runner:42
       credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME_RM82 }}
-        password: ${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,7 +23,7 @@ jobs:
 
       - name: Log in to Docker Hub
         run: |
-          echo "${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME_RM82 }}" --password-stdin
+          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
 
       - name: Extract metadata
         id: meta

--- a/.forgejo/workflows/build-push-freeradius.yml
+++ b/.forgejo/workflows/build-push-freeradius.yml
@@ -1,0 +1,40 @@
+---
+name: Build and Push docker-alpine-freeradius
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
+
+jobs:
+  build-and-push:
+    runs-on: forgejo-runner
+    container:
+      image: renedocker82/forgejo-runner:42
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USERNAME_RM82 }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+
+      - name: Log in to Docker Hub
+        run: |
+          echo "${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME_RM82 }}" --password-stdin
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          docker buildx build \
+            --push \
+            -t networklessons/docker-alpine-freeradius:latest \
+            -t networklessons/docker-alpine-freeradius:${{ forgejo.run_number }} \
+            containers/docker-alpine-freeradius/

--- a/.forgejo/workflows/build-push-lab-node-ubuntu.yml
+++ b/.forgejo/workflows/build-push-lab-node-ubuntu.yml
@@ -12,8 +12,8 @@ jobs:
     container:
       image: renedocker82/forgejo-runner:42
       credentials:
-        username: ${{ secrets.DOCKER_HUB_USERNAME_RM82 }}
-        password: ${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,7 +23,7 @@ jobs:
 
       - name: Log in to Docker Hub
         run: |
-          echo "${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME_RM82 }}" --password-stdin
+          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
 
       - name: Extract metadata
         id: meta

--- a/.forgejo/workflows/build-push-lab-node-ubuntu.yml
+++ b/.forgejo/workflows/build-push-lab-node-ubuntu.yml
@@ -1,0 +1,40 @@
+---
+name: Build and Push lab-node-ubuntu
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
+
+jobs:
+  build-and-push:
+    runs-on: forgejo-runner
+    container:
+      image: renedocker82/forgejo-runner:42
+      credentials:
+        username: ${{ secrets.DOCKER_HUB_USERNAME_RM82 }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+
+      - name: Log in to Docker Hub
+        run: |
+          echo "${{ secrets.DOCKER_HUB_PASSWORD_RM82 }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME_RM82 }}" --password-stdin
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          docker buildx build \
+            --push \
+            -t networklessons/lab-node-ubuntu:latest \
+            -t networklessons/lab-node-ubuntu:${{ forgejo.run_number }} \
+            containers/lab-node-ubuntu/

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,9 @@
+# Containers
+
+This folder contains Docker container images maintained by [networklessons.com](https://networklessons.com). Each subfolder holds the Dockerfile and supporting files for a specific container. Forgejo workflows in [.forgejo/workflows/](../.forgejo/workflows/) build and push each image to Docker Hub automatically every Sunday.
+
+| Container | Description | Docker Hub |
+|-----------|-------------|------------|
+| [docker-alpine-cisco-yang-explorer](docker-alpine-cisco-yang-explorer/) | Cisco Yang Explorer web UI running on Alpine Linux | [networklessons/docker-alpine-cisco-yang-explorer](https://hub.docker.com/r/networklessons/docker-alpine-cisco-yang-explorer) |
+| [docker-alpine-freeradius](docker-alpine-freeradius/) | FreeRADIUS server running on Alpine Linux | [networklessons/docker-alpine-freeradius](https://hub.docker.com/r/networklessons/docker-alpine-freeradius) |
+| [lab-node-ubuntu](lab-node-ubuntu/) | Ubuntu-based node with networking tools for lab environments | [networklessons/lab-node-ubuntu](https://hub.docker.com/r/networklessons/lab-node-ubuntu) |

--- a/containers/docker-alpine-cisco-yang-explorer/Dockerfile
+++ b/containers/docker-alpine-cisco-yang-explorer/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.9
+
+# Install required packages
+RUN apk add \
+gcc \
+git \
+python \
+python-dev \
+py-pip \
+py-crypto \
+py-lxml \
+py-virtualenv && \
+pip install pyang graphviz
+
+# Install Cisco Yang Explorer
+WORKDIR /cisco-yang-explorer
+RUN git clone https://github.com/CiscoDevNet/yang-explorer.git && \
+cd yang-explorer && \
+sh setup.sh && \
+sed -i 's/bash/sh/g' start.sh && \
+sed -i -e 's/HOST=\'localhost\'/HOST=$HOSTNAME/g' start.sh
+
+WORKDIR /cisco-yang-explorer/yang-explorer
+CMD ["sh", "start.sh"]

--- a/containers/docker-alpine-cisco-yang-explorer/README.md
+++ b/containers/docker-alpine-cisco-yang-explorer/README.md
@@ -1,0 +1,34 @@
+# Cisco Yang Explorer
+
+Container image that runs [Cisco Yang Explorer](https://github.com/CiscoDevNet/yang-explorer) on [Alpine Linux](https://hub.docker.com/_/alpine).
+
+Cisco Yang Explorer is a web-based tool for browsing, editing, and testing YANG data models for network devices. It supports NETCONF and lets you interact with device YANG models through a graphical interface — useful for learning and testing model-driven programmability.
+
+## Docker Hub
+
+The image is available on Docker Hub: [networklessons/docker-alpine-cisco-yang-explorer](https://hub.docker.com/r/networklessons/docker-alpine-cisco-yang-explorer)
+
+## How to use
+
+Start the container and open the following URL in your browser:
+
+```
+http://localhost:8088/static/YangExplorer.html
+```
+
+### Docker run
+
+```
+docker run -p 8088:8088 networklessons/docker-alpine-cisco-yang-explorer
+```
+
+### Docker Compose
+
+```yaml
+version: '2'
+services:
+  cisco-yang-explorer:
+    image: networklessons/docker-alpine-cisco-yang-explorer
+    ports:
+      - 8088:8088/tcp
+```

--- a/containers/docker-alpine-freeradius/Dockerfile
+++ b/containers/docker-alpine-freeradius/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest
+LABEL maintainer="info@networklessons.com"
+
+RUN apk update && \
+    apk add \
+    freeradius \
+    freeradius-eap \
+    freeradius-radclient && \
+    rm /var/cache/apk/*
+
+# Redirect logs to STDOUT
+RUN ln -sf /dev/stdout /var/log/radius/radius.log
+
+EXPOSE \
+    1812/udp \
+    1813/udp
+
+CMD ["radiusd","-xx","-f"]

--- a/containers/docker-alpine-freeradius/README.md
+++ b/containers/docker-alpine-freeradius/README.md
@@ -1,0 +1,50 @@
+# FreeRADIUS
+
+A lightweight container image that runs [FreeRADIUS](https://freeradius.org/) on [Alpine Linux](https://hub.docker.com/_/alpine).
+
+FreeRADIUS is a widely used open-source RADIUS server that handles authentication, authorization, and accounting (AAA) for network access. This image is useful for lab environments where you need a RADIUS server for testing 802.1X, EAP, or network device AAA authentication.
+
+## Docker Hub
+
+The image is available on Docker Hub: [networklessons/docker-alpine-freeradius](https://hub.docker.com/r/networklessons/docker-alpine-freeradius)
+
+## Configuration
+
+Configure the following files before starting the container. Example files are included in this folder.
+
+- `clients.conf` — defines RADIUS clients (switches, routers) and their shared secrets
+- `users` — defines user accounts and attributes such as VLAN assignments
+- `eap` — EAP module configuration for 802.1X authentication (optional)
+
+## How to use
+
+### Docker run
+
+```
+docker run \
+  -p 1812:1812/udp \
+  -p 1813:1813/udp \
+  -v /path/to/clients.conf:/etc/raddb/clients.conf \
+  -v /path/to/users:/etc/raddb/users \
+  --name freeradius \
+  networklessons/docker-alpine-freeradius
+```
+
+### Docker Compose
+
+```yaml
+version: '2'
+services:
+  freeradius:
+    image: networklessons/docker-alpine-freeradius
+    ports:
+      - 1812:1812/udp
+      - 1813:1813/udp
+    volumes:
+      - "./clients.conf:/etc/raddb/clients.conf"
+      - "./users:/etc/raddb/users"
+```
+
+## Kubernetes
+
+Deployment manifests, ConfigMaps, and Services for running this container in Kubernetes are available in the [kubernetes/](kubernetes/) folder.

--- a/containers/docker-alpine-freeradius/clients.conf
+++ b/containers/docker-alpine-freeradius/clients.conf
@@ -1,0 +1,4 @@
+client CISCO {
+  ipaddr		= 192.168.1.0/24
+  secret		= CISCO 
+  }

--- a/containers/docker-alpine-freeradius/docker-compose.yml
+++ b/containers/docker-alpine-freeradius/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+ freeradius:
+  image: networklessons/docker-alpine-freeradius
+  ports:
+   - 1812:1812/udp
+   - 1813:1813/udp
+  volumes:
+   - "./clients.conf:/etc/raddb/clients.conf"
+   - "./users:/etc/raddb/users"
+   - "./eap:/etc/raddb/mods-enabled/eap"

--- a/containers/docker-alpine-freeradius/eap
+++ b/containers/docker-alpine-freeradius/eap
@@ -1,0 +1,10 @@
+eap {
+        default_eap_type = md5
+        timer_expire = 60
+        ignore_unknown_eap_types = no
+        cisco_accounting_username_bug = no
+        max_sessions = ${max_requests}
+
+        md5 {
+        }
+}

--- a/containers/docker-alpine-freeradius/kubernetes/config-map-clients.yml
+++ b/containers/docker-alpine-freeradius/kubernetes/config-map-clients.yml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: config-map-freeradius-clients
+data:
+  clients: |
+    client CISCO {
+      ipaddr		= 192.168.1.0/24
+      secret		= CISCO
+      }

--- a/containers/docker-alpine-freeradius/kubernetes/config-map-users.yml
+++ b/containers/docker-alpine-freeradius/kubernetes/config-map-users.yml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: config-map-freeradius-users
+data:
+  users: |
+
+    user1           Cleartext-Password := "labtime"
+                    Tunnel-Type := "VLAN",
+                    Tunnel-Medium-Type := "IEEE-802",
+                    Tunnel-Private-Group-ID := "10"

--- a/containers/docker-alpine-freeradius/kubernetes/deployment-freeradius.yml
+++ b/containers/docker-alpine-freeradius/kubernetes/deployment-freeradius.yml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: deployment-freeradius
+  namespace: "default"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: freeradius
+        phase: "production"
+    spec:
+      containers:
+      - name: freeradius
+        image: networklessons/docker-alpine-freeradius:latest
+        resources:
+          requests:
+            memory: 10Mi
+            cpu: 10m
+          limits:
+            memory: 2000Mi
+            cpu: 1000m
+        ports:
+        - containerPort: 1812
+          protocol: UDP
+        - containerPort: 1813
+          protocol: UDP
+        volumeMounts:
+        - name: freeradius-clients
+          mountPath: /etc/raddb/clients.conf
+          subPath: clients.conf
+        - name: freeradius-users
+          mountPath: /etc/raddb/users
+          subPath: users
+      volumes:
+      - name: freeradius-clients
+        configMap:
+          name: config-map-freeradius-clients
+          items:
+          - key: clients
+            path: clients.conf
+      - name: freeradius-users
+        configMap:
+          name: config-map-freeradius-users
+          items:
+          - key: users
+            path: users

--- a/containers/docker-alpine-freeradius/kubernetes/service-freeradius-accounting.yml
+++ b/containers/docker-alpine-freeradius/kubernetes/service-freeradius-accounting.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-freeradius-accounting
+spec:
+  type: NodePort
+  ports:
+  - name: freeradius-accounting
+    protocol: UDP
+    port: 1813
+    targetPort: 1813
+  selector:
+    name: freeradius

--- a/containers/docker-alpine-freeradius/kubernetes/service-freeradius-authentication.yml
+++ b/containers/docker-alpine-freeradius/kubernetes/service-freeradius-authentication.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-freeradius-authentication
+spec:
+  type: NodePort
+  ports:
+  - name: freeradius-authentication
+    protocol: UDP
+    port: 1812
+    targetPort: 1812
+  selector:
+    name: freeradius

--- a/containers/docker-alpine-freeradius/users
+++ b/containers/docker-alpine-freeradius/users
@@ -1,0 +1,9 @@
+user1           Cleartext-Password := "user1password"
+                Tunnel-Type := "VLAN",
+                Tunnel-Medium-Type := "IEEE-802",
+                Tunnel-Private-Group-ID := "10"
+
+user2           Cleartext-Password := "user2password"
+                Tunnel-Type := "VLAN",
+                Tunnel-Medium-Type := "IEEE-802",
+                Tunnel-Private-Group-ID := "20"

--- a/containers/lab-node-ubuntu/Dockerfile
+++ b/containers/lab-node-ubuntu/Dockerfile
@@ -1,0 +1,33 @@
+# Use Ubuntu 24.04 as the base image
+FROM ubuntu:24.04
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update apt cache and install networking tools
+RUN apt-get update && apt-get install -y \
+    vim \
+    iputils-ping \
+    iproute2 \
+    curl \
+    netcat \
+    dnsutils \
+    nmap \
+    iperf3 \
+    hping3 \
+    tcpdump \
+    socat \
+    openssh-server \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add lab user for SSH.
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1000 lab && \
+    echo 'lab:lab' | chpasswd && \
+    mkdir /var/run/sshd
+
+# Grant lab user passwordless sudo privileges
+RUN echo 'lab ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/lab
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/containers/lab-node-ubuntu/README.md
+++ b/containers/lab-node-ubuntu/README.md
@@ -1,0 +1,88 @@
+# Lab Node Ubuntu
+
+[Lab Node Ubuntu on Docker Hub](https://hub.docker.com/r/networklessons/lab-node-ubuntu)
+
+> **Warning:** Do not use this container in production. It contains default usernames, passwords, and/or keys and is intended only for locally hosted labs.
+
+Ubuntu 24.04 base image pre-loaded with networking tools:
+
+- vim
+- nmap
+- iperf3
+- hping3
+- tcpdump
+- curl, netcat, dnsutils, socat
+- openssh-server
+- iproute2
+
+Use this as a host, server, or node in emulators such as EVE-NG, Containerlab, GNS3, etc.
+
+## SSH
+
+The container runs an SSH server on port 22. A `lab` user (password: `lab`) is created at boot with passwordless sudo. To switch to root:
+
+```
+sudo su
+```
+
+## Change MAC address
+
+```
+ip link set dev eth1 address 00:50:c2:53:40:01
+```
+
+## Change IP address
+
+### Delete the current IP address
+
+Find the current address:
+
+```
+ip addr show eth1
+```
+
+Then remove it:
+
+```
+ip addr del current.ip.address/xx dev eth1
+```
+
+### Add the new IP address
+
+```
+ip addr add 192.168.12.1/24 dev eth1
+```
+
+### Enable the interface
+
+```
+ip link set eth1 up
+```
+
+## ARP / NDISC
+
+### View ARP cache
+
+```
+ip neigh show dev eth1
+```
+
+### Flush ARP & NDISC cache
+
+```
+ip -s -s neighbor flush all
+```
+
+## Static routes
+
+View current routes:
+
+```
+ip route
+```
+
+Add a static route:
+
+```
+ip route add 192.168.0.0/16 via 192.168.12.254 dev eth1
+```


### PR DESCRIPTION
Migrates three standalone container repos into the monorepo:
- docker-alpine-cisco-yang-explorer
- docker-alpine-freeradius
- lab-node-ubuntu

Each container has its own subfolder under containers/ with a Dockerfile
and README. Forgejo workflows build and push to Docker Hub every Sunday.