### PR TITLE
Update cisco-yang-explorer to Ubuntu 24.04 with Python 3

### DIFF
--- a/containers/docker-alpine-cisco-yang-explorer/Dockerfile
+++ b/containers/docker-alpine-cisco-yang-explorer/Dockerfile
@@ -1,24 +1,28 @@
-FROM alpine:3.9
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN apk add \
-gcc \
-git \
-python \
-python-dev \
-py-pip \
-py-crypto \
-py-lxml \
-py-virtualenv && \
-pip install pyang graphviz
+RUN apt-get update && apt-get install -y \
+    gcc \
+    git \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-lxml \
+    python3-virtualenv \
+    libssl-dev \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install pyang graphviz --break-system-packages
 
 # Install Cisco Yang Explorer
 WORKDIR /cisco-yang-explorer
 RUN git clone https://github.com/CiscoDevNet/yang-explorer.git && \
-cd yang-explorer && \
-sh setup.sh && \
-sed -i 's/bash/sh/g' start.sh && \
-sed -i -e 's/HOST=\'localhost\'/HOST=$HOSTNAME/g' start.sh
+    cd yang-explorer && \
+    sh setup.sh && \
+    sed -i 's/bash/sh/g' start.sh && \
+    sed -i "s/HOST='localhost'/HOST=\$HOSTNAME/g" start.sh
 
 WORKDIR /cisco-yang-explorer/yang-explorer
 CMD ["sh", "start.sh"]


### PR DESCRIPTION
- Replace alpine:3.9 with ubuntu:24.04
- Switch from apk to apt-get with Python 3 packages
- Fix sed quoting error for HOST='localhost' substitution using double quotes
- Add --break-system-packages for pip3 (required by Ubuntu 24 PEP 668)
- Add libssl-dev and libffi-dev for build dependencies
- Clean apt cache after install

https://claude.ai/code/session_01Db7Die4AM9uzBhChvHpygU