### PR TITLE
fix: replace jq with awk in get-containers job

### DIFF
--- a/.forgejo/workflows/update-dockerhub-descriptions.yml
+++ b/.forgejo/workflows/update-dockerhub-descriptions.yml
@@ -25,7 +25,7 @@ jobs:
       - name: List containers
         id: list
         run: |
-          containers=$(find containers -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          containers=$(find containers -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "\"%s\"",$0} END{printf "]"}')
           echo "containers=$containers" >> $GITHUB_OUTPUT
 
   update-descriptions:


### PR DESCRIPTION
jq is not available in renedocker82/forgejo-runner:42, causing the
List containers step to fail with exit code 127. awk achieves the
same JSON array output without any extra dependency.

https://claude.ai/code/session_016txXXTYZYfNFT9NHJqCX9c