### PR TITLE
Fix Docker Hub secret name: use DOCKER_HUB_PASSWORD instead of DOCKER_HUB_PAT

### DIFF
--- a/.forgejo/workflows/update-dockerhub-descriptions.yml
+++ b/.forgejo/workflows/update-dockerhub-descriptions.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           python3 .forgejo/scripts/update_dockerhub_readme.py \
             --username "${{ secrets.DOCKER_HUB_USERNAME }}" \
-            --password "${{ secrets.DOCKER_HUB_PAT }}" \
+            --password "${{ secrets.DOCKER_HUB_PASSWORD }}" \
             --repository "networklessons/${{ matrix.container }}" \
             --readme-filepath "containers/${{ matrix.container }}/README.md" \
             --short-description "${{ github.event.repository.description }}" \


### PR DESCRIPTION
## Summary

- The `update-dockerhub-descriptions` workflow was passing `DOCKER_HUB_PAT` to the script's `--password` argument, but that secret does not exist
- Changed to `DOCKER_HUB_PASSWORD` to match the secrets available on the runner

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` and confirm it completes without a missing-secret error
- [ ] Verify Docker Hub descriptions are updated for all three containers

https://claude.ai/code/session_015pzZDkxYBuezhg31bKr2oe

---
_Generated by [Claude Code](https://claude.ai/code/session_015pzZDkxYBuezhg31bKr2oe)_